### PR TITLE
feat: add distributed tracing support to `posthog-node`-package

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,6 @@
 ...
 
 ## Checklist
-- [ ] Tests for new code (if applicable)
-- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
+
+-   [ ] Tests for new code (if applicable)
+-   [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)

--- a/.github/workflows/ava-tests.yml
+++ b/.github/workflows/ava-tests.yml
@@ -1,22 +1,22 @@
 name: CI
 
 on:
-  - pull_request
+    - pull_request
 
 jobs:
-  build:
-    name: Ava tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+    build:
+        name: Ava tests
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
 
-      - name: Install Node 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
+            - name: Install Node 12
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 12
 
-      - name: Install dependencies from npm
-        run: yarn
+            - name: Install dependencies from npm
+              run: yarn
 
-      - name: Run tests
-        run: yarn test
+            - name: Run tests
+              run: yarn test

--- a/feature-flags.js
+++ b/feature-flags.js
@@ -2,9 +2,10 @@ const axios = require('axios')
 const crypto = require('crypto')
 const ms = require('ms')
 const version = require('./package.json').version
+const libraryTracer = require('./tracing')
+const tracingApi = require('@opentelemetry/api')
 
 const LONG_SCALE = 0xfffffffffffffff
-
 
 class FeatureFlagsPoller {
     constructor({ pollingInterval, personalApiKey, projectApiKey, timeout, host, featureFlagCalledCallback }) {
@@ -22,9 +23,16 @@ class FeatureFlagsPoller {
     }
 
     async isFeatureEnabled(key, distinctId, defaultResult = false) {
+        const span = libraryTracer.startSpan('isFeatureEnabled', { kind: tracingApi.SpanKind.SERVER })
+        span.setAttribute('posthog.distinctid', distinctId)
+        span.setAttribute('posthog.flag', key)
+        span.setAttribute('posthog.fallback_result', defaultResult)
+
         await this.loadFeatureFlags()
 
         if (!this.loadedSuccessfullyOnce) {
+            span.setAttribute('posthog.value', defaultResult)
+            span.end()
             return defaultResult
         }
 
@@ -38,6 +46,8 @@ class FeatureFlagsPoller {
         }
 
         if (!featureFlag) {
+            span.setAttribute('posthog.value', defaultResult)
+            span.end()
             return defaultResult
         }
 
@@ -55,13 +65,19 @@ class FeatureFlagsPoller {
         }
 
         this.featureFlagCalledCallback(key, distinctId, isFlagEnabledResponse)
+
+        span.setAttribute('posthog.value', isFlagEnabledResponse)
+        span.end()
         return isFlagEnabledResponse
     }
 
     async loadFeatureFlags(forceReload = false) {
+        const span = libraryTracer.startSpan('loadFeatureFlags')
+        span.setAttribute('posthog.force_reload', forceReload)
         if (!this.loadedSuccessfullyOnce || forceReload) {
             await this._loadFeatureFlags()
         }
+        span.end()
     }
 
     /* istanbul ignore next */

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,31 +59,28 @@ declare module 'posthog-node' {
          */
         alias(data: { distinctId: string; alias: string }): void
 
-
         /**
-         * @description PostHog feature flags (https://posthog.com/docs/features/feature-flags) 
+         * @description PostHog feature flags (https://posthog.com/docs/features/feature-flags)
          * allow you to safely deploy and roll back new features. Once you've created a feature flag in PostHog,
-         * you can use this method to check if the flag is on for a given user, allowing you to create logic to turn 
+         * you can use this method to check if the flag is on for a given user, allowing you to create logic to turn
          * features on and off for different user groups or individual users.
          * IMPORTANT: To use this method, you need to specify `personalApiKey` in your config! More info: https://posthog.com/docs/api/overview
          * @param key the unique key of your feature flag
          * @param distinctId the current unique id
          * @param defaultResult optional - default value to be returned if the feature flag is not on for the user
-        */
+         */
         isFeatureEnabled(key: string, distinctId: string, defaultResult?: boolean): Promise<boolean>
 
-
         /**
-         * @description Force an immediate reload of the polled feature flags. Please note that they are 
+         * @description Force an immediate reload of the polled feature flags. Please note that they are
          * already polled automatically at a regular interval.
-        */
+         */
         reloadFeatureFlags(): Promise<void>
 
         /**
          * @description Flushes the events still in the queue and clears the feature flags poller to allow for
          * a clean shutdown.
-        */
+         */
         shutdown(): void
     }
-
 }

--- a/index.js
+++ b/index.js
@@ -86,10 +86,7 @@ class PostHog {
             looselyValidate(message, type)
         } catch (e) {
             if (e.message === 'Your message must be < 32 kB.') {
-                console.log(
-                    'Your message must be < 32 kB.',
-                    JSON.stringify(message)
-                )
+                console.log('Your message must be < 32 kB.', JSON.stringify(message))
                 return
             }
             throw e

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "size-limit": [
         {
-            "limit": "25 KB",
+            "limit": "115 KB",
             "path": "index.js"
         }
     ],
@@ -42,6 +42,7 @@
         "funnels"
     ],
     "dependencies": {
+        "@opentelemetry/api": "^1.0.0",
         "axios": "^0.21.1",
         "axios-retry": "^3.1.9",
         "component-type": "^1.2.1",

--- a/tests/assets/mockFlagsResponse.js
+++ b/tests/assets/mockFlagsResponse.js
@@ -1,60 +1,60 @@
 const mockSimpleFlagResponse = {
-    "count": 1,
-    "next": null,
-    "previous": null,
-    "results": [
+    count: 1,
+    next: null,
+    previous: null,
+    results: [
         {
-            "id": 719,
-            "name": "",
-            "key": "simpleFlag",
-            "filters": {
-                "groups": [
+            id: 719,
+            name: '',
+            key: 'simpleFlag',
+            filters: {
+                groups: [
                     {
-                        "properties": [],
-                        "rollout_percentage": null
-                    }
-                ]
+                        properties: [],
+                        rollout_percentage: null,
+                    },
+                ],
             },
-            "deleted": false,
-            "active": true,
-            "is_simple_flag": true,
-            "rollout_percentage": null
+            deleted: false,
+            active: true,
+            is_simple_flag: true,
+            rollout_percentage: null,
         },
         {
-            "id": 720,
-            "name": "",
-            "key": "enabled-flag",
-            "filters": {
-                "groups": [
+            id: 720,
+            name: '',
+            key: 'enabled-flag',
+            filters: {
+                groups: [
                     {
-                        "properties": [],
-                        "rollout_percentage": null
-                    }
-                ]
+                        properties: [],
+                        rollout_percentage: null,
+                    },
+                ],
             },
-            "deleted": false,
-            "active": true,
-            "is_simple_flag": false,
-            "rollout_percentage": null
+            deleted: false,
+            active: true,
+            is_simple_flag: false,
+            rollout_percentage: null,
         },
         {
-            "id": 721,
-            "name": "",
-            "key": "disabled-flag",
-            "filters": {
-                "groups": [
+            id: 721,
+            name: '',
+            key: 'disabled-flag',
+            filters: {
+                groups: [
                     {
-                        "properties": [],
-                        "rollout_percentage": null
-                    }
-                ]
+                        properties: [],
+                        rollout_percentage: null,
+                    },
+                ],
             },
-            "deleted": false,
-            "active": true,
-            "is_simple_flag": false,
-            "rollout_percentage": null
+            deleted: false,
+            active: true,
+            is_simple_flag: false,
+            rollout_percentage: null,
         },
-    ]
+    ],
 }
 
 module.exports = { mockSimpleFlagResponse }

--- a/tests/test.js
+++ b/tests/test.js
@@ -8,7 +8,6 @@ import PostHog from '../index'
 import { version } from '../package'
 import { mockSimpleFlagResponse } from './assets/mockFlagsResponse'
 
-
 const noop = () => {}
 
 const port = 6042
@@ -64,7 +63,7 @@ test.before.cb((t) => {
         })
         .post('/decide', (req, res) => {
             return res.status(200).json({
-                featureFlags: ['enabled-flag']
+                featureFlags: ['enabled-flag'],
             })
         })
         .listen(port, t.end)
@@ -275,7 +274,7 @@ test('flush - time out if configured', async (t) => {
         },
     ]
     await t.throws(client.flush(), 'timeout of 500ms exceeded')
-}) 
+})
 
 test('flush - skip when client is disabled', async (t) => {
     const client = createClient({ enable: false })
@@ -427,7 +426,10 @@ test('allows messages > 32 kB', (t) => {
 test('feature flags - require personalApiKey', async (t) => {
     const client = createClient()
 
-    await t.throws(client.isFeatureEnabled('simpleFlag', 'some id'), 'You have to specify the option personalApiKey to use feature flags.')
+    await t.throws(
+        client.isFeatureEnabled('simpleFlag', 'some id'),
+        'You have to specify the option personalApiKey to use feature flags.'
+    )
 
     client.shutdown()
 })
@@ -469,11 +471,15 @@ test('feature flags - default override', async (t) => {
 test('feature flags - simple flag calculation', async (t) => {
     const client = createClient({ personalApiKey: 'my very secret key' })
 
-    // This tests that the hashing + mathematical operations across libs are consistent 
-    let flagEnabled = client.featureFlagsPoller._isSimpleFlagEnabled({key: 'a', distinctId: 'b', rolloutPercentage: 42})
+    // This tests that the hashing + mathematical operations across libs are consistent
+    let flagEnabled = client.featureFlagsPoller._isSimpleFlagEnabled({
+        key: 'a',
+        distinctId: 'b',
+        rolloutPercentage: 42,
+    })
     t.is(flagEnabled, true)
 
-    flagEnabled = client.featureFlagsPoller._isSimpleFlagEnabled({key: 'a', distinctId: 'b', rolloutPercentage: 40})
+    flagEnabled = client.featureFlagsPoller._isSimpleFlagEnabled({ key: 'a', distinctId: 'b', rolloutPercentage: 40 })
     t.is(flagEnabled, false)
 
     client.shutdown()

--- a/tracing.js
+++ b/tracing.js
@@ -1,0 +1,7 @@
+const api = require('@opentelemetry/api')
+
+const version = require('./package.json').version
+
+const libraryTracer = api.trace.getTracer('posthog-node', version)
+
+module.exports = libraryTracer

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,6 +167,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@opentelemetry/api@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0.tgz#cc7712009095697f8a9492ee375daa08588ba263"
+  integrity sha512-TcdhrGy+ehLIFs79/TcWiHiPujishrhSgQ7wxvWvk8WY2YT8Np/pYXmRP94voG3N8GJ/5nIVyzacfViwhN50AQ==
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0", "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"


### PR DESCRIPTION
## Changes

Introduces support for distributed tracing to allow adding trace span
for the `isFeatureEnabled`-call to see all the fature flag calls in e.g.
network requests

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
