### PR TITLE
Update property types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,14 +10,9 @@ declare module 'posthog-node' {
         personalApiKey?: string
         featureFlagsPollingInterval?: number
     }
-
-    interface CommonParamsInterfacePropertiesProp {
-        [key: string]: string | number | Array<any | { [key: string]: string | number }>
-    }
-
     interface IdentifyMessage {
         distinctId: string
-        properties?: CommonParamsInterfacePropertiesProp
+        properties?: Record<string | number, any>
     }
 
     interface EventMessage extends IdentifyMessage {


### PR DESCRIPTION
## Changes

Properties can essentially be anything, so we shouldn't do strict type checking here. Not all types passed would be particularly useful in the UI, but we can still process them.

They can be a boolean, `null`, a number, a string, a deeply nested object, an array of objects, whatever. Hence `Record<string | number, any>`

Closes #40 

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
