### PR TITLE
fix: feature flag pollingInterval wrong init

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ class PostHog {
             }
 
             this.featureFlagsPoller = new FeatureFlagsPoller({
-                featureFlagsPollingInterval:
+                pollingInterval:
                     typeof options.featureFlagsPollingInterval === 'number'
                         ? options.featureFlagsPollingInterval
                         : FIVE_MINUTES,


### PR DESCRIPTION
## Changes

Fix wrong feature flags poller init of the pollingInterval. Which will cause serious unlimited API calling with no interval time

We use the `featureFlagsPollingInterval` variable when init it. but used the wrong `pollingInterval` when actually init it.

```
this.featureFlagsPoller = new FeatureFlagsPoller({
                featureFlagsPollingInterval:
                    typeof options.featureFlagsPollingInterval === 'number'
                        ? options.featureFlagsPollingInterval
                        : FIVE_MINUTES,
                personalApiKey: options.personalApiKey,
                projectApiKey: apiKey,
                timeout: options.timeout || false,
                host: this.host,
                featureFlagCalledCallback,
            })
```
...

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
