### PR TITLE
fix missing rolloutPercentage data when check simple flag

### DIFF
--- a/feature-flags.js
+++ b/feature-flags.js
@@ -58,7 +58,7 @@ class FeatureFlagsPoller {
             isFlagEnabledResponse = this._isSimpleFlagEnabled({
                 key,
                 distinctId,
-                rolloutPercentage: featureFlag.rolloutPercentage,
+                rolloutPercentage: featureFlag.rollout_percentage,
             })
         } else {
             const res = await this._request({ path: 'decide', method: 'POST', data: { distinct_id: distinctId } })

--- a/feature-flags.js
+++ b/feature-flags.js
@@ -106,8 +106,12 @@ class FeatureFlagsPoller {
     // sha1('a.b') should equal '69f6642c9d71b463485b4faf4e989dc3fe77a8c6'
     // integerRepresentationOfHashSubset / LONG_SCALE for sha1('a.b') should equal 0.4139158829615955
     _isSimpleFlagEnabled({ key, distinctId, rolloutPercentage }) {
-        if (!rolloutPercentage) {
-            return true
+        if (rolloutPercentage === null || rolloutPercentage === undefined) {
+            return true;
+        }
+
+        if (rolloutPercentage === 0) {
+            return false;
         }
         const sha1Hash = crypto.createHash('sha1')
         sha1Hash.update(`${key}.${distinctId}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-node",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "PostHog Node.js integration",
     "license": "MIT",
     "repository": "PostHog/posthog-node",


### PR DESCRIPTION
## Changes

change from "rolloutPercentage" to "rollout_percentage" to match return values from posthog server.

## Checklist
- [ ] Tests for new code (if applicable)
- [ ] TypeScript definitions (module.d.ts) updated and in sync with library exports (if applicable)
